### PR TITLE
Fix double onSave(afterCommit) notification issue #37

### DIFF
--- a/reports-ui/src/main/java/io/jmix/reportsui/screen/report/edit/ReportEditor.java
+++ b/reports-ui/src/main/java/io/jmix/reportsui/screen/report/edit/ReportEditor.java
@@ -180,12 +180,11 @@ public class ReportEditor extends StandardEditor<Report> {
         setScreenCaption();
     }
 
-    @Subscribe(target = Target.DATA_CONTEXT)
-    protected void onPostCommit(DataContext.PostCommitEvent event) {
-        notifications.create(Notifications.NotificationType.TRAY)
-                .withCaption(messages.formatMessage(getClass(), "notification.completeSuccessfully", getEditedEntity().getName()))
-                .show();
+    @Override
+    protected String getSaveNotificationCaption(){
+        return messages.formatMessage(getClass(), "notification.completeSuccessfully", getEditedEntity().getName());
     }
+
 
     protected void setScreenCaption() {
         if (!StringUtils.isEmpty(getEditedEntity().getName())) {


### PR DESCRIPTION
Remove onPostCommit EL which sends second notification

In UI https://github.com/Haulmont/jmix-ui/pull/355/commits/6c75be859e2dc7521f84615b2a503074ba124820
refactored API to override bad message(the specified name occurs twice in notification) with report's own