### PR TITLE
Fix report import error in ReportBrowse #42

### DIFF
--- a/reports-ui/src/main/java/io/jmix/reportsui/screen/report/importdialog/ReportImportDialog.java
+++ b/reports-ui/src/main/java/io/jmix/reportsui/screen/report/importdialog/ReportImportDialog.java
@@ -85,7 +85,7 @@ public class ReportImportDialog extends Screen {
         if (validationErrors.isEmpty()) {
             ReportImportResult result = importReport();
 
-            if (result.endedWithoutException()) {
+            if (result.hasErrors()) {
                 notifications.create(Notifications.NotificationType.HUMANIZED)
                         .withCaption(messages.formatMessage(getClass(), "importResult",
                                 result.getCreatedReports().size(),

--- a/reports-ui/src/main/java/io/jmix/reportsui/screen/report/importdialog/ReportImportDialog.java
+++ b/reports-ui/src/main/java/io/jmix/reportsui/screen/report/importdialog/ReportImportDialog.java
@@ -80,7 +80,7 @@ public class ReportImportDialog extends Screen {
 
         if (validationErrors.isEmpty()) {
             importReport();
-            closeWithDefaultAction();
+            close(StandardOutcome.COMMIT);
         }
 
         screenValidation.showValidationErrors(getWindow().getFrameOwner(), validationErrors);

--- a/reports-ui/src/main/java/io/jmix/reportsui/screen/report/importdialog/ReportImportDialog.java
+++ b/reports-ui/src/main/java/io/jmix/reportsui/screen/report/importdialog/ReportImportDialog.java
@@ -85,7 +85,7 @@ public class ReportImportDialog extends Screen {
         if (validationErrors.isEmpty()) {
             ReportImportResult result = importReport();
 
-            if (result.hasErrors()) {
+            if (!result.hasErrors()) {
                 notifications.create(Notifications.NotificationType.HUMANIZED)
                         .withCaption(messages.formatMessage(getClass(), "importResult",
                                 result.getCreatedReports().size(),

--- a/reports-ui/src/main/java/io/jmix/reportsui/screen/report/importdialog/ReportImportDialog.java
+++ b/reports-ui/src/main/java/io/jmix/reportsui/screen/report/importdialog/ReportImportDialog.java
@@ -60,6 +60,7 @@ public class ReportImportDialog extends Screen {
 
     @Subscribe
     protected void onInit(InitEvent event) {
+        fileUploadField.setMode(FileStorageUploadField.FileStoragePutMode.MANUAL);
         importRoles.setValue(Boolean.TRUE);
     }
 

--- a/reports/src/main/java/io/jmix/reports/ReportImportExportImpl.java
+++ b/reports/src/main/java/io/jmix/reports/ReportImportExportImpl.java
@@ -296,7 +296,8 @@ public class ReportImportExportImpl implements ReportImportExport, ReportImportE
         Report existingReport = dataManager.load(Report.class)
                 .id(report.getId())
                 .fetchPlan(FetchPlan.INSTANCE_NAME)
-                .one();
+                .optional()
+                .orElse(null);
 
         report = saveReport(report);
         importResult.addImportedReport(report);

--- a/reports/src/main/java/io/jmix/reports/entity/ReportImportResult.java
+++ b/reports/src/main/java/io/jmix/reports/entity/ReportImportResult.java
@@ -31,6 +31,8 @@ public class ReportImportResult implements Serializable {
     protected Collection<Report> updatedReports;
     protected Collection<Report> createdReports;
 
+    protected Collection<Exception> innerExceptions;
+
     public Collection<Report> getImportedReports() {
         return importedReports == null ? Collections.emptySet() : importedReports;
     }
@@ -41,6 +43,17 @@ public class ReportImportResult implements Serializable {
 
     public Collection<Report> getCreatedReports() {
         return createdReports == null ? Collections.emptySet() : createdReports;
+    }
+
+    public Collection<Exception> getInnerExceptions() {
+        return innerExceptions == null ? Collections.emptyList() : innerExceptions;
+    }
+
+    public boolean endedWithoutException(){
+        return getInnerExceptions().size() == 0;
+    }
+    public void addException(Exception exception){
+        getInnerExceptions().add(exception);
     }
 
     public void addImportedReport(Report importedReport) {

--- a/reports/src/main/java/io/jmix/reports/entity/ReportImportResult.java
+++ b/reports/src/main/java/io/jmix/reports/entity/ReportImportResult.java
@@ -50,7 +50,7 @@ public class ReportImportResult implements Serializable {
     }
 
     public boolean hasErrors(){
-        return getInnerExceptions().size() == 0;
+        return getInnerExceptions().size() != 0;
     }
 
     public void addException(Exception exception){

--- a/reports/src/main/java/io/jmix/reports/entity/ReportImportResult.java
+++ b/reports/src/main/java/io/jmix/reports/entity/ReportImportResult.java
@@ -49,9 +49,10 @@ public class ReportImportResult implements Serializable {
         return innerExceptions == null ? Collections.emptyList() : innerExceptions;
     }
 
-    public boolean endedWithoutException(){
+    public boolean hasErrors(){
         return getInnerExceptions().size() == 0;
     }
+
     public void addException(Exception exception){
         getInnerExceptions().add(exception);
     }


### PR DESCRIPTION
reports-ui/src/main/java/io/jmix/reportsui/screen/report/importdialog/ReportImportDialog.java 
63 line override defualt 'IMMEDIATE' in FileStorageUploadFieldImpl to 'MANUAL'
when IMMEDIATE is in state of the class, it invokes method that is erasing fileId property. It is required to be in import logics (everything is fine, but import-export thinks that was an error)

.one() is useless because under here is null-check for existingReport, but one throws error if query result was empty
