### PR TITLE
Fix ReportInputParameter default value is not saved #26

### DIFF
--- a/reports-ui/src/main/java/io/jmix/reportsui/screen/parameter/edit/ParameterEditor.java
+++ b/reports-ui/src/main/java/io/jmix/reportsui/screen/parameter/edit/ParameterEditor.java
@@ -157,13 +157,20 @@ public class ParameterEditor extends StandardEditor<ReportInputParameter> {
     protected ParameterFieldCreator parameterFieldCreator;
 
     @Subscribe
-    protected void onInit(Screen.InitEvent event) {
+    protected void onInit(InitEvent event) {
         parameterTypeField.setOptionsList(Arrays.asList(ParameterType.TEXT, ParameterType.NUMERIC, ParameterType.BOOLEAN, ParameterType.ENUMERATION,
                 ParameterType.DATE, ParameterType.TIME, ParameterType.DATETIME, ParameterType.ENTITY, ParameterType.ENTITY_LIST));
-
         initMetaClassLookup();
         initEnumsLookup();
         initCodeEditors();
+    }
+
+    @Subscribe
+    public void onBeforeShow(BeforeShowEvent event) {
+        if(getEditedEntity().getParameterClass() == null){
+            getEditedEntity().setType(parameterTypeField.getValue());
+            getEditedEntity().setParameterClass(parameterClassResolver.resolveClass(getEditedEntity()));
+        }
     }
 
     @Install(to = "localeField", subject = "contextHelpIconClickHandler")

--- a/reports-ui/src/main/java/io/jmix/reportsui/screen/parameter/edit/ParameterEditor.java
+++ b/reports-ui/src/main/java/io/jmix/reportsui/screen/parameter/edit/ParameterEditor.java
@@ -167,9 +167,11 @@ public class ParameterEditor extends StandardEditor<ReportInputParameter> {
 
     @Subscribe
     public void onBeforeShow(BeforeShowEvent event) {
-        if(getEditedEntity().getParameterClass() == null){
-            getEditedEntity().setType(parameterTypeField.getValue());
-            getEditedEntity().setParameterClass(parameterClassResolver.resolveClass(getEditedEntity()));
+        ReportInputParameter editedParam = getEditedEntity();
+
+        if (editedParam.getParameterClass() == null) {
+            editedParam.setType(parameterTypeField.getValue());
+            editedParam.setParameterClass(parameterClassResolver.resolveClass(editedParam));
         }
     }
 


### PR DESCRIPTION
The issue with string parameter in fact not caused with string at all. String is first template (default) value, for example if number be first default value then number will raise this bug. It can be solved if you change string to any format, for example - number, and then back to string. After all string default value will be saved. I used onBeforeShow listener because this solution depends on initilizing parameter class field of entity parameter. I could init it with String class and use EntityInitEvent but for more flex i  had use default value of ui field.